### PR TITLE
Added Windows compatibility to Gnuplot installation verification, also changed Exception name to PEP recomendations.

### DIFF
--- a/gnuplot_install_comprobation.py
+++ b/gnuplot_install_comprobation.py
@@ -1,20 +1,25 @@
 from os import path as os_path
 from os import name as os_name
 
-class UninstalledGnuplotException(Exception):
+class UninstalledGnuplotError(Exception):
     """Raise if is not possible to find a gnuplot installation"""
-    def __init__(self, message="There is no installation for Gnuplot. Install Gnuplot before using PyGnuplot."):
-        self.__message = message
-        super().__init__(self.__message)
+    def __init__(self, gnuplot_path):
+        self.__gnuplot_path = gnuplot_path
+        super().__init__(
+            f"There is no installation for Gnuplot in {self.__gnuplot_path}. Install Gnuplot before using PyGnuplot."
+        )
 
 def verify_gnuplot_installation():
-    """ Verify in posix os the installation of Gnuplot"""
+    """ Verify Gnuplot installation in default paths in posix os nt"""
     if os_name == "posix":
-        has_gnuplot = os_path.exists("/usr/bin/gnuplot")
-        if has_gnuplot == False:
-            raise UninstalledGnuplotException
+        gnuplot_path = "/usr/bin/gnuplot"
+    elif os_name == "nt":
+        gnuplot_path = r"C:\Program Files\gnuplot"
+    has_gnuplot = os_path.exists(gnuplot_path)
+    if has_gnuplot == False:
+        raise UninstalledGnuplotError(gnuplot_path)
 
 if __name__ == "__main__":
     # test
     verify_gnuplot_installation()
-    #raise UninstalledGnuplotException
+    #raise UninstalledGnuplotError(r"C:\Program Files\gnuplot")


### PR DESCRIPTION
I have added Windows (nt)  compatibility to the method I previously created to find if an installation of Gnuplot was made.

If you think all is ok, I would love a merge to the Master branch. (:

If you need help with any of this contributions (like retrocompatibility or anything), I surely be happy to help.